### PR TITLE
fix: correct boilerplate enum key from allowed_values to options

### DIFF
--- a/.boilerplate/boilerplate.yml
+++ b/.boilerplate/boilerplate.yml
@@ -39,7 +39,7 @@ variables:
     description: "VPC Subnets scope, required if vpc_enabled is true, options: private, intra"
     type: enum
     default: intra
-    allowed_values:
+    options:
       - private
       - intra
     confirm: true


### PR DESCRIPTION
## Summary

- Rename `allowed_values` to `options` in the vpc_subnets enum variable definition in `.boilerplate/boilerplate.yml` to match the correct boilerplate schema key

+semver: patch